### PR TITLE
Fix worker script

### DIFF
--- a/api/docker/usr/local/share/worker/run.sh
+++ b/api/docker/usr/local/share/worker/run.sh
@@ -2,9 +2,9 @@
 
 set -xe
 
-EXTRA_ARGUMENTS=''
+EXTRA_ARGUMENTS=()
 if [ ! -z "$WORKER_CONNECTION_NAME" ]; then
-    EXTRA_ARGUMENTS=" --connection=${WORKER_CONNECTION_NAME}"
+    EXTRA_ARGUMENTS+=("--connection=${WORKER_CONNECTION_NAME}")
 fi
 
 if [ -z "$SYMFONY_ENV" ]; then


### PR DESCRIPTION
Fixes:
```
19:23:45 ERROR     [console] Error thrown while running command "-e=dev continuouspipe:message:pull-and-consume ' --connection=main'". Message: "No default connection configured. Please use the `--connection` argument to specify the connection to use" ["error" => InvalidArgumentException { …},"command" => "-e=dev continuouspipe:message:pull-and-consume ' --connection=main'","message" => "No default connection configured. Please use the `--connection` argument to specify the connection to use"] []
```

Shellcheck fixes were a bit overzealous :)