### PR TITLE
Fix Start Tide event which was getting a doctrine proxy version of Team.

### DIFF
--- a/api/src/ContinuousPipe/River/Infrastructure/Doctrine/Resources/config/River.Flow.Projections.FlatFlow.orm.xml
+++ b/api/src/ContinuousPipe/River/Infrastructure/Doctrine/Resources/config/River.Flow.Projections.FlatFlow.orm.xml
@@ -23,7 +23,7 @@
             <join-column name="user_username" referenced-column-name="username" />
         </many-to-one>
 
-        <many-to-one field="team" target-entity="ContinuousPipe\Security\Team\Team">
+        <many-to-one field="team" target-entity="ContinuousPipe\Security\Team\Team" fetch="EAGER">
             <join-column name="team_slug" referenced-column-name="slug" />
         </many-to-one>
     </entity>


### PR DESCRIPTION
The call to \ContinuousPipe\Builder\GuessUserRegistryAndUsername::createBuildRequests()
passed the $credentialsBucketUuid as null due to the FlatFlow being fetched from the
repository with Team being lazily loaded, meaning the uuid instance was not present.

Fixes:
```
worker_1       | [05-Mar-2018 20:30:49 UTC] [2018-03-05 20:30:49] app.ERROR: Could not process message, did not re-queue {"exception":"[object] (TypeError(code: 0): Argument 5 passed to ContinuousPipe\\Builder\\GuessUserRegistryAndUsername::createBuildRequests() must implement interface Ramsey\\Uuid\\UuidInterface, null given, called in /app/src/ContinuousPipe/River/Task/Build/BuildTask.php on line 95 at /app/src/ContinuousPipe/Builder/GuessUserRegistryAndUsername.php:48)"} []
worker_1       | 20:30:49 ERROR     [app] Could not process message, did not re-queue ["exception" => TypeError { …}] []
```