### PR TITLE
Fix managed service account not loading correctly in worker.

### DIFF
--- a/api/src/ContinuousPipe/Managed/ClusterCreation/GoogleCloud/GKEClusterAccountCreator.php
+++ b/api/src/ContinuousPipe/Managed/ClusterCreation/GoogleCloud/GKEClusterAccountCreator.php
@@ -61,7 +61,7 @@ class GKEClusterAccountCreator implements ClusterCreator
             throw new ClusterCreationException('Can\'t get cluster from GKE API', $e->getCode(), $e);
         }
 
-        return new Kubernetes(
+        $newCluster = new Kubernetes(
             $clusterIdentifier,
             $this->endpoint($cluster->getEndpoint()),
             $this->version($cluster->getCurrentMasterVersion()),
@@ -70,13 +70,15 @@ class GKEClusterAccountCreator implements ClusterCreator
             [],
             null,
             null, // (Don't add the CA certificate for now - https://inviqa.atlassian.net/browse/CD-599) $cluster->getMasterAuthentication()->getClusterCaCertificate(),
-            $base64EncodedServiceAccount,
+            null,
             new Cluster\ClusterCredentials(
                 $cluster->getMasterAuthentication()->getUsername(),
                 $cluster->getMasterAuthentication()->getPassword()
                 // (Don't use client certificate for now - https://inviqa.atlassian.net/browse/CD-606) $cluster->getMasterAuthentication()->getClientCertificate()
             )
         );
+        $newCluster->setCredentials(new Cluster\ClusterCredentials(null, null, null, null, $base64EncodedServiceAccount));
+        return $newCluster;
     }
 
     /**

--- a/api/src/ContinuousPipe/Security/Credentials/Cluster/Kubernetes.php
+++ b/api/src/ContinuousPipe/Security/Credentials/Cluster/Kubernetes.php
@@ -125,13 +125,14 @@ class Kubernetes extends Cluster
      */
     public function getCredentials()
     {
-        return $this->credentials ?: new ClusterCredentials(
-            $this->username,
-            $this->password,
-            $this->clientCertificate,
-            null,
-            $this->googleCloudServiceAccount
-        );
+        return $this->credentials && !$this->credentials->isEmpty()
+            ? $this->credentials : new ClusterCredentials(
+                $this->username,
+                $this->password,
+                $this->clientCertificate,
+                null,
+                $this->googleCloudServiceAccount
+            );
     }
 
     /**


### PR DESCRIPTION
Doctrine loads up an empty `ClusterCredentials` instance if the cluster.credentials_* fields are null, so check if the credentials instance is empty as well as not null before replacing it. 

Also fix the initial persistence of a `cluster.google_cloud_service_account` field when creating a managed cluster from a service account, storing in `cluster.credentials_google_cloud_service_account` instead.