### PR TITLE
Add RIVER_UI_URL to the env.dist

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -54,6 +54,7 @@ GOOGLE_CONTAINER_BUILDER_SERVICE_ACCOUNT_PATH=/runtime/keys/google-container-bui
 ## How do you access your ContinuousPipe instance?
 # Configure the URLs and ways you will access ContinuousPipe. The public URL is the URL
 RIVER_API_URL=http://localhost:81
+RIVER_UI_URL=http://localhost:80
 
 ## Security
 # We need a password, a master key and a few certificates. We'll generate them for you or... you'll enter them :)


### PR DESCRIPTION
This PR allows the `RIVER_UI_URL` to be set as part of the `generate-kube-configuration`.

Without this URL being set into the `main-config` the GitHub PR callback URL to view the tide looks like the following - 

```
https://void/team/project/UUID/UUID/logs
```
As part of the configuration, the user has the ability to set this to their ngrok URL if using the `docker-compose` setup. Otherwise, they should set this to their desired UI URL and manually update their DNS when they have the URL of the generated endpoint from K8s
